### PR TITLE
Fix a crash for CursorIndexOutOfBoundsException

### DIFF
--- a/screenshotDetection/src/main/java/com/akexorcist/screenshotdetection/ScreenshotDetectionDelegate.kt
+++ b/screenshotDetection/src/main/java/com/akexorcist/screenshotdetection/ScreenshotDetectionDelegate.kt
@@ -132,9 +132,18 @@ class ScreenshotDetectionDelegate(
                 null
             )?.let { cursor ->
                 cursor.moveToFirst()
-                val path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA))
+                if (cursor.count > 0) {
+                    val columnIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+                    var path: String? = null
+                    if (columnIndex > 0) {
+                        path = cursor.getString(columnIndex)
+                    }
+                    cursor.close()
+                    return path
+                }
+
                 cursor.close()
-                return path
+                return null
             }
         } catch (e: Exception) {
             Log.w(TAG, e.message ?: "")


### PR DESCRIPTION
## Problem
`cursor.getString` can make the `CursorIndexOutOfBoundsException` when the cursor's length of the database is zero.

## Situation
The situation can happen when the `READ_EXTERNAL_STORAGE` permission is not allowed by the OS ( >= Android 12)

## Solution
Add a guard for the case that the cursor's length of the database is zero.